### PR TITLE
Fix: Preserve photo when editing a wine

### DIFF
--- a/app/src/androidTest/java/pl/nataliana/mywine/WineDatabaseTest.kt
+++ b/app/src/androidTest/java/pl/nataliana/mywine/WineDatabaseTest.kt
@@ -40,7 +40,7 @@ class WineDatabaseTest {
     @Test
     @Throws(Exception::class)
     fun insertAndGetWine() {
-        val wine = Wine("Wine test", "red", 1234, 3F, 23.0, "dry")
+        val wine = Wine("Wine test", "red", 1234, 3F, 23.0, "dry", null)
         wineDao.insert(wine)
         val oneWine = wineDao.getWineDetails(1)
         assertEquals(oneWine?.color, "red")

--- a/app/src/main/java/pl/nataliana/mywine/ui/detail/EditWineFragment.kt
+++ b/app/src/main/java/pl/nataliana/mywine/ui/detail/EditWineFragment.kt
@@ -72,7 +72,7 @@ class EditWineFragment : Fragment() {
                 .show()
             return
         } else {
-            val data = applyWineData()
+            val data = applyWineData(binding.wine?.photo)
             val updatedWine = Wine(
                 // we checked above that name and color are not empty
                 data.getStringExtra(EXTRA_NAME)!!,
@@ -80,7 +80,8 @@ class EditWineFragment : Fragment() {
                 data.getIntExtra(EXTRA_YEAR, 0),
                 data.getFloatExtra(EXTRA_RATE, 0F),
                 data.getDoubleExtra(EXTRA_PRICE, 0.0),
-                data.getStringExtra(EXTRA_TYPE)
+                data.getStringExtra(EXTRA_TYPE),
+                data.getStringExtra(EXTRA_PHOTO)
             )
 
             uiScope.launch {
@@ -95,7 +96,7 @@ class EditWineFragment : Fragment() {
         }
     }
 
-    private fun applyWineData(): Intent {
+    private fun applyWineData(photo: String?): Intent {
         return Intent().apply {
             val name = binding.nameEdit.text.toString()
             val color = determineWineColor()
@@ -110,6 +111,7 @@ class EditWineFragment : Fragment() {
             putExtra(EXTRA_RATE, rating)
             putExtra(EXTRA_PRICE, price)
             putExtra(EXTRA_TYPE, type)
+            putExtra(EXTRA_PHOTO, photo)
         }
     }
 
@@ -152,5 +154,6 @@ class EditWineFragment : Fragment() {
         const val EXTRA_RATE = "pl.nataliana.mywine.EXTRA_RATE"
         const val EXTRA_PRICE = "pl.nataliana.mywine.EXTRA_PRICE"
         const val EXTRA_TYPE = "pl.nataliana.mywine.EXTRA_TYPE"
+        const val EXTRA_PHOTO = "pl.nataliana.mywine.EXTRA_PHOTO"
     }
 }


### PR DESCRIPTION
This change fixes a bug where the photo of a wine was not preserved when editing the wine. The `EditWineFragment` was not passing the photo information when creating the updated `Wine` object. The `WineDatabaseTest` was also updated to reflect the changes in the `Wine` data class.